### PR TITLE
docs: add qq-ai-bot integration example

### DIFF
--- a/examples/qq-ai-bot-compose.yml
+++ b/examples/qq-ai-bot-compose.yml
@@ -1,0 +1,48 @@
+version: "3"
+
+services:
+  llonebot:
+    image: initialencounter/llonebot:latest
+    container_name: llonebot
+    restart: always
+    ports:
+      - 3001:3001
+      - 3080:3080
+    volumes:
+      - ./QQ:/root/.config/QQ
+      - ./llonebot:/root/llonebot
+    networks:
+      - qq_ai_bot
+
+  qq-ai-bot:
+    image: ghcr.io/happysnaker/qq-ai-bot:latest
+    container_name: qq-ai-bot
+    restart: always
+    environment:
+      - BOT_PORT=8080
+      - DATA_DIR=/app/data
+      - SESSION_FILE_PATH=/app/data/sessions.json
+      - ONEBOT_MODE=forward
+      # Docker 私有网络内可直接填 ws://llonebot:3001
+      # 跨主机 / 公网 / 反向代理请改成 wss://...
+      - ONEBOT_FORWARD_WS_URL=${ONEBOT_FORWARD_WS_URL}
+      - ONEBOT_ACCESS_TOKEN=llonebot-shared-token
+      - ONEBOT_ALLOW_GROUP=true
+      - ONEBOT_REQUIRE_MENTION_IN_GROUP=true
+      - ONEBOT_ALLOW_PRIVATE=true
+      - ONEBOT_PROGRESS_MODE=message
+      - ACP_AGENT_COMMAND=node
+      - 'ACP_AGENT_ARGS_JSON=["dist/examples/mock-acp-agent.js"]'
+      - ACP_AGENT_WORKDIR=/app
+      - ACP_REUSE_SESSION=true
+      - ACP_VERBOSE_MODE=verbose
+    ports:
+      - 18080:8080
+    volumes:
+      - ./qq-ai-bot/data:/app/data
+    networks:
+      - qq_ai_bot
+
+networks:
+  qq_ai_bot:
+    driver: bridge

--- a/examples/qq-ai-bot-compose.yml
+++ b/examples/qq-ai-bot-compose.yml
@@ -23,8 +23,8 @@ services:
       - DATA_DIR=/app/data
       - SESSION_FILE_PATH=/app/data/sessions.json
       - ONEBOT_MODE=forward
-      # Docker 私有网络内可直接填 ws://llonebot:3001
-      # 跨主机 / 公网 / 反向代理请改成 wss://...
+      # Docker 私有网络内可直接填容器内网 WebSocket 地址
+      # 跨主机 / 公网 / 反向代理请改成带 TLS 的 WSS 地址
       - ONEBOT_FORWARD_WS_URL=${ONEBOT_FORWARD_WS_URL}
       - ONEBOT_ACCESS_TOKEN=llonebot-shared-token
       - ONEBOT_ALLOW_GROUP=true

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,8 @@ docker run -d \
 
 如果你想把 LLOneBot 作为 **QQ ↔ AI** 链路的协议侧，可以直接接一个现成的 `qq-ai-bot`：
 
+完整 compose 示例见：[examples/qq-ai-bot-compose.yml](./examples/qq-ai-bot-compose.yml)
+
 ```yaml
 version: "3"
 services:
@@ -71,7 +73,7 @@ services:
       - DATA_DIR=/app/data
       - SESSION_FILE_PATH=/app/data/sessions.json
       - ONEBOT_MODE=forward
-      - ONEBOT_FORWARD_WS_URL=ws://llonebot:3001
+      - ONEBOT_FORWARD_WS_URL=${ONEBOT_FORWARD_WS_URL}
       - ONEBOT_ACCESS_TOKEN=llonebot-shared-token
       - ONEBOT_ALLOW_GROUP=true
       - ONEBOT_REQUIRE_MENTION_IN_GROUP=true
@@ -107,6 +109,8 @@ networks:
   "reportSelfMessage": false
 }
 ```
+
+如果你是在 **Docker 私有桥接网络** 内直接把两个容器互连，`ONEBOT_FORWARD_WS_URL` 可以填容器内网地址；如果你是跨主机、跨网络段，或者需要经过公网 / 反向代理，请改成带 TLS 的 `wss://...` 地址。
 
 注意：`qq-ai-bot` 里的 `ONEBOT_ACCESS_TOKEN` 必须和 LLOneBot OneBot11 配置里的 `token` 保持一致。
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,77 @@ docker run -d \
   initialencounter/llonebot:latest
 ```
 
+## 接入 qq-ai-bot（可选）
+
+如果你想把 LLOneBot 作为 **QQ ↔ AI** 链路的协议侧，可以直接接一个现成的 `qq-ai-bot`：
+
+```yaml
+version: "3"
+services:
+  llonebot:
+    image: initialencounter/llonebot:latest
+    container_name: llonebot
+    restart: always
+    ports:
+      - 3001:3001
+      - 3080:3080
+    volumes:
+      - ./QQ:/root/.config/QQ
+      - ./llonebot:/root/llonebot
+    networks:
+      - qq_ai_bot
+
+  qq-ai-bot:
+    image: ghcr.io/happysnaker/qq-ai-bot:latest
+    container_name: qq-ai-bot
+    restart: always
+    environment:
+      - BOT_PORT=8080
+      - DATA_DIR=/app/data
+      - SESSION_FILE_PATH=/app/data/sessions.json
+      - ONEBOT_MODE=forward
+      - ONEBOT_FORWARD_WS_URL=ws://llonebot:3001
+      - ONEBOT_ACCESS_TOKEN=llonebot-shared-token
+      - ONEBOT_ALLOW_GROUP=true
+      - ONEBOT_REQUIRE_MENTION_IN_GROUP=true
+      - ONEBOT_ALLOW_PRIVATE=true
+      - ONEBOT_PROGRESS_MODE=message
+      - ACP_AGENT_COMMAND=node
+      - 'ACP_AGENT_ARGS_JSON=["dist/examples/mock-acp-agent.js"]'
+      - ACP_AGENT_WORKDIR=/app
+      - ACP_REUSE_SESSION=true
+      - ACP_VERBOSE_MODE=verbose
+    ports:
+      - 18080:8080
+    volumes:
+      - ./qq-ai-bot/data:/app/data
+    networks:
+      - qq_ai_bot
+
+networks:
+  qq_ai_bot:
+    driver: bridge
+```
+
+然后在 LLOneBot 的 OneBot11 配置里启用一个 **正向 WS**：
+
+```json5
+{
+  "type": "ws",
+  "enable": true,
+  "host": "0.0.0.0",
+  "port": 3001,
+  "token": "llonebot-shared-token",
+  "messageFormat": "array",
+  "reportSelfMessage": false
+}
+```
+
+注意：`qq-ai-bot` 里的 `ONEBOT_ACCESS_TOKEN` 必须和 LLOneBot OneBot11 配置里的 `token` 保持一致。
+
+- 项目地址：<https://github.com/happysnaker/qq-ai-bot>
+- 项目页：<https://happysnaker.github.io/qq-ai-bot/>
+
 ## 快速体验
 
 ```bash


### PR DESCRIPTION
Adds an optional `qq-ai-bot` integration example to the README.

Why this is useful:
- shows a concrete **LLOneBot + qq-ai-bot** deployment path for users who want a self-hosted QQ ↔ AI bot stack
- includes the matching OneBot11 forward WebSocket config and token note, which is a common integration footgun
- points to a runnable public image and project page instead of only a conceptual description

This is intentionally optional and does not change the existing Docker / Nix quickstart path for plain LLOneBot users.

## 由 Sourcery 提供的摘要

为 QQ-to-AI 部署记录 LLOneBot 与 qq-ai-bot 之间的一种可选集成路径。

文档：
- 添加一个 docker-compose 示例，展示如何在使用前向 WebSocket 模式和共享令牌配置的情况下，将 LLOneBot 与 qq-ai-bot 一起运行。
- 记录在与 qq-ai-bot 一起使用时，LLOneBot 所需的 OneBot11 前向 WebSocket 配置，并链接到 qq-ai-bot 的相关资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document an optional integration path between LLOneBot and qq-ai-bot for QQ-to-AI deployments.

Documentation:
- Add a docker-compose example showing how to run LLOneBot together with qq-ai-bot using forward WebSocket mode and shared token configuration.
- Document the required OneBot11 forward WebSocket configuration for LLOneBot when used with qq-ai-bot and link to qq-ai-bot resources.

</details>